### PR TITLE
Implement loading UI and color filters

### DIFF
--- a/src/MainPage.jsx
+++ b/src/MainPage.jsx
@@ -20,6 +20,17 @@ export default function MainPage() {
         <span className="col-3 input-group-text">modo de visualização</span>
         <select className="col-9 form-select" id="modes-list"></select>
       </div>
+      <div className="row input-group mb-2" id="color-selector">
+        <span className="col-3 input-group-text">tipos de nó</span>
+        <div className="col-9 d-flex flex-wrap" id="color-options"></div>
+      </div>
+      <div id="loading-spinner" className="text-center my-2" style={{display:'none'}}>
+        <div className="spinner-border" role="status"></div>
+        <div id="loading-message" className="mt-2">carregando...</div>
+        <div className="progress mt-2" style={{height:'5px'}}>
+          <div id="alpha_value" className="progress-bar" role="progressbar" style={{width:'0%'}} aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
+        </div>
+      </div>
       <div className="row" id="graph-view" style={{display:'none'}}>
         <svg id="main_svg"></svg>
         <a id="downloadAnchorElem"></a>

--- a/src/js/data/dataManager.js
+++ b/src/js/data/dataManager.js
@@ -3,7 +3,7 @@
  * Handles data operations, filtering, and processing
  */
 
-import { getFiltersByMode } from "../core/config.js";
+import { getFiltersByMode, NODE_GROUPS, DEFAULT_MODE } from "../core/config.js";
 
 // Main data storage
 let graphData = {
@@ -15,6 +15,9 @@ let filteredData = {
     nodes: [],
     links: []
 };
+
+// Groups currently selected for filtering
+let selectedGroups = NODE_GROUPS.slice();
 
 /**
  * Set the graph data
@@ -39,6 +42,28 @@ export function getGraphData() {
  */
 export function getFilteredData() {
     return filteredData;
+}
+
+/**
+ * Update group filter combining mode filter and selected groups
+ */
+function updateGroupFilter() {
+    const mode = localStorage.getItem("selectedMode") || DEFAULT_MODE;
+    const modeFilterObj = getFiltersByMode(mode);
+    const modeFilter = modeFilterObj.group;
+    currentFilters.group = (group) => {
+        const modeOk = modeFilter ? modeFilter(group) : true;
+        return modeOk && selectedGroups.includes(group);
+    };
+}
+
+/**
+ * Set groups selected by user
+ * @param {Array} groups
+ */
+export function setSelectedNodeGroups(groups) {
+    selectedGroups = groups.slice();
+    updateGroupFilter();
 }
 
 /**
@@ -172,6 +197,7 @@ export function getFilters() {
 export function initializeFilters(mode) {
     console.log("initializeFilters mode %o", mode);
     setFilters(getFiltersByMode(mode));
+    updateGroupFilter();
 }
 
 /**

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -3,11 +3,11 @@
  * Entry point for the application
  */
 
-import { USER_MODE, PROJECT_MODE, INDICATORS_MODE, BEESWARM_MODE, DEFAULT_MODE } from "./core/config.js";
+import { USER_MODE, PROJECT_MODE, INDICATORS_MODE, BEESWARM_MODE, DEFAULT_MODE, NODE_GROUPS } from "./core/config.js";
 import { initializeRenderer } from "./visualization/graphRenderer.js";
-import { initializeUI, initializeProjectList, initializeModeSelector, initializePeriodicCheckButtonControls } from "./ui/uiManager.js";
+import { initializeUI, initializeProjectList, initializeModeSelector, initializePeriodicCheckButtonControls, initializeColorSelector } from "./ui/uiManager.js";
 import { getProjects, drawProject, updateGraph } from "./core/projectManager.js";
-import { applyFilters } from "./data/dataManager.js";
+import { applyFilters, setSelectedNodeGroups, getFilters } from "./data/dataManager.js";
 import { startPeriodicCheck, stopPeriodicCheck, getPeriodicCheckStatus } from "./core/periodicCheck.js";
 import { checkAuthentication } from "./core/auth.js";
 
@@ -35,7 +35,7 @@ export async function initializeApp() {
     const accessToken = localStorage.getItem("strateegiaAccessToken");
 
     // Initialize renderer
-    initializeRenderer("svg#main_svg", "#project-chooser");
+    initializeRenderer("svg#main_svg", "#graph-view");
 
     // Initialize UI
     initializeUI();
@@ -68,6 +68,13 @@ export async function initializeApp() {
         localStorage.setItem("selectedMode", selectedMode);
         const selectedProject = localStorage.getItem("selectedProject");
         drawProject(accessToken, selectedProject, selectedMode);
+    });
+
+    // Initialize color selector
+    initializeColorSelector(NODE_GROUPS, (groups) => {
+        setSelectedNodeGroups(groups);
+        const filtered = applyFilters(getFilters());
+        updateGraph(filtered);
     });
 
     // Draw initial project

--- a/src/js/ui/uiManager.js
+++ b/src/js/ui/uiManager.js
@@ -3,7 +3,7 @@
  * Handles UI interactions and display
  */
 
-import { USER_MODE, PROJECT_MODE, INDICATORS_MODE, BEESWARM_MODE } from "../core/config.js";
+import { USER_MODE, PROJECT_MODE, INDICATORS_MODE, BEESWARM_MODE, NODE_GROUPS, NODE_COLORS } from "../core/config.js";
 import { filterByTime, getFilters } from "../data/dataManager.js";
 import { calculateIndicators } from "../data/statisticsManager.js";
 import { saveAsSVG } from "../visualization/graphRenderer.js";
@@ -20,6 +20,7 @@ export function initializeUI() {
 
     // Initialize export buttons
     initializeExportButtons();
+
 }
 
 /**
@@ -219,6 +220,41 @@ export function initializeModeSelector(modes, onModeChange) {
         .append("option")
         .attr("value", (d) => d)
         .text((d) => d);
+}
+
+/**
+ * Initialize node color selector
+ * @param {Array} groups - node group names
+ * @param {Function} onChange - callback when selection changes
+ */
+export function initializeColorSelector(groups, onChange) {
+    const container = d3.select("#color-options");
+    const items = container.selectAll("div.color-option")
+        .data(groups)
+        .enter()
+        .append("div")
+        .attr("class", "form-check form-check-inline me-2 color-option");
+
+    items.append("input")
+        .attr("class", "form-check-input")
+        .attr("type", "checkbox")
+        .attr("id", d => `color-${d}`)
+        .property("checked", true)
+        .on("change", () => {
+            const selected = [];
+            container.selectAll("input").each(function (d) {
+                if (d3.select(this).property("checked")) {
+                    selected.push(d);
+                }
+            });
+            onChange(selected);
+        });
+
+    items.append("label")
+        .attr("class", "form-check-label")
+        .attr("for", d => `color-${d}`)
+        .style("color", (d, i) => NODE_COLORS[i])
+        .text(d => d);
 }
 
 /**

--- a/src/js/visualization/graphRenderer.js
+++ b/src/js/visualization/graphRenderer.js
@@ -36,9 +36,12 @@ export function initializeRenderer(svgSelector, containerSelector) {
 
     // Get dimensions from container
     const container = d3.select(containerSelector);
-    const containerRect = container.node().getBoundingClientRect();
+    let containerRect = container.node().getBoundingClientRect();
+    if (containerRect.width === 0) {
+        containerRect = container.node().parentNode.getBoundingClientRect();
+    }
     width = containerRect.width;
-    height = 1000; // Fixed height or calculate based on needs
+    height = containerRect.height || 1000;
 
     // Set SVG dimensions
     svg.style("width", width + "px")
@@ -58,9 +61,15 @@ export function initializeRenderer(svgSelector, containerSelector) {
 
     // Handle window resize
     d3.select(window).on("resize", () => {
-        const containerRect = container.node().getBoundingClientRect();
-        width = containerRect.width;
-        height = containerRect.height;
+        let rect = container.node().getBoundingClientRect();
+        if (rect.width === 0) {
+            rect = container.node().parentNode.getBoundingClientRect();
+        }
+        width = rect.width;
+        height = rect.height || height;
+        svg.style("width", width + "px")
+            .style("height", height + "px")
+            .attr("viewBox", [0, 0, width, height]);
     });
 }
 


### PR DESCRIPTION
## Summary
- show a spinner on `MainPage` while data loads
- fix graph renderer width calculations for hidden containers
- add node color filtering logic with checkboxes
- wire up color selector in `main.js` and update filters

## Testing
- `npm run lint` *(fails: d3 is not defined and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_683f7fd50a34832ab32c5d34c3fd537e